### PR TITLE
fixed infinite getUser

### DIFF
--- a/src/components/BankForm.tsx
+++ b/src/components/BankForm.tsx
@@ -44,7 +44,8 @@ export function BankForm(){
         // no user found
         setOpen(true);
       })
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
 
   const formik = useFormik({


### PR DESCRIPTION
The previous version calls getUser everytime the component changes, and the getUser resolve callback updates the user state and thus the component. This creates an infinite loop of getUser causing the high reads on any page visit since Bankforms is always loaded on the dashboard.

The fix is to replace the empty second param of useEffect with [], so it only runs on mount instead of every update.